### PR TITLE
Fix missing asgi app attribute

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,6 +49,9 @@ app = FastAPI(
     lifespan=lifespan
 )
 
+# Provide an alias for environments that expect `main:App`
+App = app
+
 # 包含API路由
 app.include_router(api_router, prefix="/api/v1")
 


### PR DESCRIPTION
Add `App = app` alias in `main.py` to resolve `Attribute "App" not found in module "main"` errors.

Some environments or configurations expect the ASGI application entrypoint to be `main:App`, while the FastAPI instance is named `app`. This alias ensures compatibility without changing the primary application instance name.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8ae803c-7009-46f5-a1f8-a25ae13f3899">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8ae803c-7009-46f5-a1f8-a25ae13f3899">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

