### PR TITLE
Debug api not found error

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,8 +59,8 @@ App = FastAPI(
     lifespan=lifespan
 )
 
-# 包含API路由
-App.include_router(api_router, prefix="/api/v1")
+# 包含API路由（去掉全局前缀，直接挂载到根路径）
+App.include_router(api_router)
 
 
 @App.get("/")


### PR DESCRIPTION
Remove the `/api/v1` global prefix from API routes to make endpoints directly accessible at the root.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0c4e9da-4346-41d8-b3d0-e2c49f5edfdf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0c4e9da-4346-41d8-b3d0-e2c49f5edfdf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

