### PR TITLE
Update camel case plugin id record

### DIFF
--- a/app/models/plugin_statistic.py
+++ b/app/models/plugin_statistic.py
@@ -1,7 +1,7 @@
 """
 插件统计模型
 """
-from sqlalchemy import Column, Integer, String, select, delete
+from sqlalchemy import Column, Integer, String, select, delete, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.base import Base, get_id_column
@@ -29,6 +29,25 @@ class PluginStatistics(Base):
             select(cls).where(cls.plugin_id == pid)
         )
         return result.scalar_one_or_none()
+
+    @classmethod
+    async def read_prefer_camel(cls, db: AsyncSession, pid: str):
+        """
+        根据 plugin_id 进行不区分大小写的查询；如存在两个记录（一个全小写、一个驼峰），优先返回驼峰记录。
+        """
+        # 获取同一逻辑 plugin_id 的所有记录（不区分大小写）
+        result = await db.execute(
+            select(cls).where(func.lower(cls.plugin_id) == pid.lower())
+        )
+        items = result.scalars().all()
+        if not items:
+            return None
+        # 优先返回包含大写字符的记录（视为驼峰写法）
+        for item in items:
+            if any(ch.isupper() for ch in item.plugin_id):
+                return item
+        # 如果没有驼峰，返回第一条（应为全小写）
+        return items[0]
 
     async def update(self, db: AsyncSession, payload: dict):
         payload = {k: v for k, v in payload.items() if v is not None}

--- a/app/services/plugin_statistic.py
+++ b/app/services/plugin_statistic.py
@@ -15,8 +15,8 @@ class PluginService:
     @staticmethod
     async def install_plugin(db: AsyncSession, plugin_id: str, repo_url: str | None = None) -> Dict[str, Any]:
         """安装插件计数，并可更新仓库地址"""
-        # 查询数据库中是否存在
-        plugin = await PluginStatistics.read(db, plugin_id)
+        # 查询数据库中是否存在；当存在大小写两条记录时优先更新驼峰记录
+        plugin = await PluginStatistics.read_prefer_camel(db, plugin_id)
 
         # 如果不存在则创建
         if not plugin:


### PR DESCRIPTION
Prioritize updating camelCase `plugin_id` records to resolve historical duplicate entries in `PLUGIN_STATISTICS`.

Due to historical data, the `PLUGIN_STATISTICS` table may contain two records for the same logical `plugin_id`: one in camelCase and one in all lowercase. This change ensures that during plugin installation or updates, if both forms exist, the camelCase record is consistently targeted for modification.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f74c078-82d0-4abc-a784-051d552bb538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f74c078-82d0-4abc-a784-051d552bb538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

